### PR TITLE
correction of my circleci config file for wrongly virtualenv activation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
       - run:
           name: upload to pypi
           command: |
-            . venv/bin/activate
+            . last/bin/activate
             pip install twine
             twine upload dist/*
       


### PR DESCRIPTION
correction of my circleci config file for wrongly virtualenv activation and setting of wrong pypi paswword